### PR TITLE
Add unit tests

### DIFF
--- a/api/pkg/customerrors/error_test.go
+++ b/api/pkg/customerrors/error_test.go
@@ -1,0 +1,23 @@
+package customerrors
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPartialAccountsError(t *testing.T) {
+	err := NewPartialAccountsError(2, 1)
+	var pe *partialAccountsError
+	if !errors.As(err, &pe) {
+		t.Fatalf("unexpected type")
+	}
+	if pe.Created != 2 || pe.NotCreated != 1 {
+		t.Errorf("wrong values: %#v", pe)
+	}
+	if !errors.Is(err, ErrCreatePartialAccounts) {
+		t.Error("errors.Is failed")
+	}
+	if pe.Error() == "" {
+		t.Error("empty error message")
+	}
+}

--- a/api/pkg/utils/account_test.go
+++ b/api/pkg/utils/account_test.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"backend/api/pkg/models"
+	"testing"
+)
+
+func TestBuildAccountProxyString(t *testing.T) {
+	acc := &models.Account{ProxyIP: "1.1.1.1", ProxyPort: "8080", ProxyLogin: "u", ProxyPass: "p"}
+	if s := BuildAccountProxyString(acc); s != "u:p@1.1.1.1:8080" {
+		t.Errorf("unexpected string: %s", s)
+	}
+
+	acc.ProxyLogin = ""
+	acc.ProxyPass = ""
+	if s := BuildAccountProxyString(acc); s != "1.1.1.1:8080" {
+		t.Errorf("unexpected string without creds: %s", s)
+	}
+
+	acc.ProxyIP = ""
+	if s := BuildAccountProxyString(acc); s != "" {
+		t.Errorf("expected empty string, got: %s", s)
+	}
+}

--- a/api/pkg/utils/user_test.go
+++ b/api/pkg/utils/user_test.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"backend/api/pkg/config"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"strings"
+	"testing"
+)
+
+func TestHashPasswordAndCheck(t *testing.T) {
+	hash, err := HashPassword("pass")
+	if err != nil {
+		t.Fatalf("hash error: %v", err)
+	}
+	if !CheckPasswordHash("pass", hash) {
+		t.Error("password check failed")
+	}
+}
+
+func TestEncodeDecodeJWT(t *testing.T) {
+	config.S.JwtSecret = []byte("secret")
+	id := primitive.NewObjectID()
+	token, err := EncodeJWT(id)
+	if err != nil {
+		t.Fatalf("encode error: %v", err)
+	}
+	got, err := GetUserIdFromToken(token)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if got != id {
+		t.Errorf("expected %s got %s", id.Hex(), got.Hex())
+	}
+}
+
+func TestGenerateMnemonicAndValidate(t *testing.T) {
+	mnemonic, err := GenerateMnemonic()
+	if err != nil {
+		t.Fatalf("generate error: %v", err)
+	}
+	if len(mnemonic) != 12 {
+		t.Errorf("expected 12 words, got %d", len(mnemonic))
+	}
+	if !ValidateMnemonic(mnemonic) {
+		t.Error("generated mnemonic should be valid")
+	}
+}
+
+func TestMnemonicToSeed(t *testing.T) {
+	phrase := strings.Split("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about", " ")
+	seed := MnemonicToSeed(phrase)
+	expected := "62a772f85e4be6226108b56c0b1cf935c2490e434adec864fe47b189f1ed517d"
+	if seed != expected {
+		t.Errorf("seed mismatch: %s", seed)
+	}
+}

--- a/api/pkg/utils/utils_test.go
+++ b/api/pkg/utils/utils_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRemoveDuplicates(t *testing.T) {
+	input := []int{1, 2, 2, 3, 3, 3, 4}
+	expected := []int{1, 2, 3, 4}
+	result := RemoveDuplicates(input)
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("expected %v, got %v", expected, result)
+	}
+}
+
+func TestGenerateKeyPairAndLoad(t *testing.T) {
+	priv, _, err := GenerateKeyPair(1024)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	enc := PrivateKeyToString(priv)
+	got, err := LoadPrivateKey(enc)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if priv.N.Cmp(got.N) != 0 {
+		t.Error("loaded key mismatch")
+	}
+}
+
+func TestPublicKeyToString(t *testing.T) {
+	priv, pub, err := GenerateKeyPair(1024)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	s, err := PublicKeyToString(pub)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if s == "" {
+		t.Error("empty string")
+	}
+	// ensure LoadPrivateKey of priv doesn't affect
+	_ = priv
+}


### PR DESCRIPTION
## Summary
- add new unit tests for custom errors
- test utils for JWT, mnemonic, and duplicate removal
- add proxy string builder tests
- add tests for security helpers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6841c1e6fc84832e9171bfc9fc9d0997